### PR TITLE
Reduce size of template output

### DIFF
--- a/lib/hogan_assets/tilt.rb
+++ b/lib/hogan_assets/tilt.rb
@@ -6,15 +6,10 @@ module HoganAssets
 
     def evaluate(scope, locals, &block)
       compiled_template = Hogan.compile(data)
-      code = data.inspect
       template_name = scope.logical_path.inspect
       <<-TEMPLATE
-        (function() {
-          this.HoganTemplates || (this.HoganTemplates = {});
-          this.HoganTemplates[#{template_name}] = new Hogan.Template(#{code});
-          this.HoganTemplates[#{template_name}].r = #{compiled_template};
-          return HoganTemplates[#{template_name}];
-        }).call(this);
+        this.HoganTemplates || (this.HoganTemplates = {});
+        this.HoganTemplates[#{template_name}] = new Hogan.Template(#{compiled_template});
       TEMPLATE
     end
 

--- a/test/hogan_assets/tilt_test.rb
+++ b/test/hogan_assets/tilt_test.rb
@@ -12,14 +12,10 @@ module HoganAssets
       end.new
 
       template = HoganAssets::Tilt.new('/myapp/app/assets/templates/path/to/template.mustache') { "This is {{mustache}}" }
-      assert_equal <<END_EXPECTED, template.render(scope, {})
-        (function() {
-          this.HoganTemplates || (this.HoganTemplates = {});
-          this.HoganTemplates["path/to/template"] = new Hogan.Template("This is {{mustache}}");
-          this.HoganTemplates["path/to/template"].r = function(c,p,i){i = i || "";var b = i + "";var _ = this;b += "This is ";b += (_.v(_.f("mustache",c,p,0)));return b;;};
-          return HoganTemplates["path/to/template"];
-        }).call(this);
-END_EXPECTED
+      assert_equal <<-END_EXPECTED, template.render(scope, {})
+        this.HoganTemplates || (this.HoganTemplates = {});
+        this.HoganTemplates["path/to/template"] = new Hogan.Template(function(c,p,i){i = i || "";var b = i + "";var _ = this;b += "This is ";b += (_.v(_.f("mustache",c,p,0)));return b;;});
+      END_EXPECTED
     end
   end
 end


### PR DESCRIPTION
`Hogan.Template` doesn't need the original source. Removed to reduce download size.

Mustache is awesome and full of win. Thanks for figuring out precompiling in Sprockets!
