### PR TITLE
Updating call for Hogan.Template() for 3.0.0 to ensure lambdas (function...

### DIFF
--- a/lib/hogan_assets/tilt.rb
+++ b/lib/hogan_assets/tilt.rb
@@ -11,17 +11,21 @@ module HoganAssets
     end
 
     def evaluate(scope, locals, &block)
+      text = data # Ugly, yes, but to not taint data variable
+
       if scope.pathname.extname == '.hamstache'
         raise "Unable to complile #{scope.pathname} because haml is not available. Did you add the haml gem?" unless HoganAssets::Config.haml_available?
-        compiled_template = Haml::Engine.new(data, @options).render
-        compiled_template = Hogan.compile(compiled_template)
+        text = Haml::Engine.new(data, @options).render
+        compiled_template = Hogan.compile(source)
       else
         compiled_template = Hogan.compile(data)
       end
+      
       template_name = scope.logical_path.inspect
+
       <<-TEMPLATE
         this.HoganTemplates || (this.HoganTemplates = {});
-        this.HoganTemplates[#{template_name}] = new Hogan.Template(#{compiled_template});
+        this.HoganTemplates[#{template_name}] = new Hogan.Template(#{compiled_template}, #{text.inspect}, Hogan, {});
       TEMPLATE
     end
 

--- a/test/hogan_assets/tilt_test.rb
+++ b/test/hogan_assets/tilt_test.rb
@@ -16,7 +16,7 @@ module HoganAssets
       template = HoganAssets::Tilt.new('/myapp/app/assets/templates/path/to/template.mustache') { "This is {{mustache}}" }
       assert_equal <<-END_EXPECTED, template.render(scope, {})
         this.HoganTemplates || (this.HoganTemplates = {});
-        this.HoganTemplates[\"path/to/template\"] = new Hogan.Template({code: function (c,p,i) { var t=this;t.b(i=i||\"\");t.b(\"This is \");t.b(t.v(t.f(\"mustache\",c,p,0)));return t.fl(); },partials: {}, subs: {  }});
+        this.HoganTemplates[\"path/to/template\"] = new Hogan.Template({code: function (c,p,i) { var t=this;t.b(i=i||\"\");t.b(\"This is \");t.b(t.v(t.f(\"mustache\",c,p,0)));return t.fl(); },partials: {}, subs: {  }}, "This is {{mustache}}", Hogan, {});
       END_EXPECTED
     end
   end


### PR DESCRIPTION
This is a fix for issue #9 (https://github.com/leshill/hogan_assets/issues/9).

This passes all the proper params into Hogan.Template(), which allows it to properly evaluate lambdas in the render context.
