### PR TITLE
Configurable Haml options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ And then execute:
 
     $ bundle
 
+Hamstache compilation can be configured using [Haml options](http://haml.info/docs/yardoc/Haml/Options.html). For example:
+
+    HoganAssets::Config.configure do |config|
+      config.haml_options[:ugly] = true
+    end
+
 ## Configuration
 
 ### Lambda Support

--- a/lib/hogan_assets/config.rb
+++ b/lib/hogan_assets/config.rb
@@ -9,12 +9,13 @@ module HoganAssets
   #   config.lambda_support = false
   #   config.path_prefix = 'templates'
   #   config.template_extensions = ['mustache', 'hamstache']
+  #   config.haml_options[:ugly] = true
   # end
   #
   module Config
     extend self
 
-    attr_writer :lambda_support, :path_prefix, :template_extensions, :template_namespace
+    attr_writer :lambda_support, :path_prefix, :template_extensions, :template_namespace, :haml_options
 
     def configure
       yield self
@@ -42,6 +43,10 @@ module HoganAssets
                                else
                                  ['mustache']
                                end
+    end
+
+    def haml_options
+      @haml_options ||= {}
     end
   end
 end

--- a/lib/hogan_assets/tilt.rb
+++ b/lib/hogan_assets/tilt.rb
@@ -15,7 +15,7 @@ module HoganAssets
       template_namespace = HoganAssets::Config.template_namespace
 
       text = if template_path.is_hamstache?
-        raise "Unable to complile #{template_path.full_path} because haml is not available. Did you add the haml gem?" unless HoganAssets::Config.haml_available?
+        raise "Unable to compile #{template_path.full_path} because haml is not available. Did you add the haml gem?" unless HoganAssets::Config.haml_available?
         Haml::Engine.new(data, HoganAssets::Config.haml_options.merge(@options)).render
       else
         data

--- a/lib/hogan_assets/tilt.rb
+++ b/lib/hogan_assets/tilt.rb
@@ -16,7 +16,7 @@ module HoganAssets
 
       text = if template_path.is_hamstache?
         raise "Unable to complile #{template_path.full_path} because haml is not available. Did you add the haml gem?" unless HoganAssets::Config.haml_available?
-        Haml::Engine.new(data, @options).render
+        Haml::Engine.new(data, HoganAssets::Config.haml_options.merge(@options)).render
       else
         data
       end

--- a/test/hogan_assets/tilt_test.rb
+++ b/test/hogan_assets/tilt_test.rb
@@ -90,5 +90,14 @@ module HoganAssets
         this.JST[\"path/to/template\"] = new Hogan.Template({code: function (c,p,i) { var t=this;t.b(i=i||\"\");t.b(\"This is \");t.b(t.v(t.f(\"mustache\",c,p,0)));return t.fl(); },partials: {}, subs: {  }}, "", Hogan, {});
       END_EXPECTED
     end
+
+    def test_haml_options
+      HoganAssets::Config.configure do |config|
+        config.haml_options[:ugly] = true
+      end
+      scope = make_scope '/myapp/app/assets/javascripts', 'path/to/template.hamstache'
+      template = HoganAssets::Tilt.new(scope.s_path) { "%p\n  This is {{mustache}}" }
+      assert_match /\"This is "/, template.render(scope, {})
+    end
   end
 end


### PR DESCRIPTION
Expose Haml options in `HoganAssets::Config`. This is mainly done so that `ugly` option can be enabled to avoid extra whitespace in compile templated.

I can't figure out any reason why `ugly` option shouldn't be on by defaultl. The generated HTML is not really readable within templates anyway. However, this is left as a further improvement.
