### PR TITLE
Added yaml config option

### DIFF
--- a/lib/hogan_assets/config.rb
+++ b/lib/hogan_assets/config.rb
@@ -13,6 +13,26 @@ module HoganAssets
   #   config.slim_options[:pretty] = false
   # end
   #
+  # Change config options in a YAML file (config/hogan_assets.yml):
+  #
+  # defaults: &defaults
+  #   lambda_support: false
+  #   path_prefix: 'templates'
+  #   template_extensions:
+  #     - 'hamstache'
+  #     - 'slimstache'
+  #   template_namespace: 'JST'
+  #   haml_options:
+  #     ugly: true
+  #   slim_options:
+  #     pretty: false
+  # development:
+  #   <<: *defaults
+  # test:
+  #   <<: *defaults
+  # production:
+  #   <<: *defaults
+  #
   module Config
     extend self
 
@@ -20,6 +40,33 @@ module HoganAssets
 
     def configure
       yield self
+    end
+
+    def load_yml!
+      @lambda_support      = yml['lambda_support'] if yml.has_key?('lambda_support')
+      @path_prefix         = yml['path_prefix'] if yml.has_key?('path_prefix')
+      @template_extensions = yml['template_extensions'] if yml.has_key?('template_extensions')
+      @template_namespace  = yml['template_namespace'] if yml.has_key?('template_namespace')
+      @haml_options        = yml['haml_options'] if yml.has_key?('haml_options')
+      @slim_options        = yml['slim_options'] if yml.has_key?('slim_options')
+      @haml_options.symbolize_keys
+      @slim_options.symbolize_keys
+    end
+
+    def yml
+      begin
+        @yml ||= YAML.load(ERB.new(IO.read(yml_path)).result)[Rails.env] rescue nil || {}
+      rescue Psych::SyntaxError
+        @yml = {}
+      end
+    end
+
+    def yml_exists?
+      File.exists?(yml_path)
+    end
+
+    def yml_path
+      Rails.root.join('config', 'hogan_assets.yml')
     end
 
     def haml_available?

--- a/lib/hogan_assets/engine.rb
+++ b/lib/hogan_assets/engine.rb
@@ -2,6 +2,7 @@ module HoganAssets
   class Engine < ::Rails::Engine
     initializer "sprockets.hogan", :after => "sprockets.environment", :group => :all do |app|
       next unless app.assets
+      HoganAssets::Config.load_yml! if HoganAssets::Config.yml_exists?
       HoganAssets::Config.template_extensions.each do |ext|
         app.assets.register_engine(".#{ext}", Tilt)
       end


### PR DESCRIPTION
Adds the ability to configure the gem using a yaml file in config/hogan_assets.yml instead of configuring with an initializer.

I have the gem installed in the assets group and I don't want to include the gem in production so I want to avoid using an initializer.
