### PR TITLE
pass scope and locals up the chain, allows haml rails helpers

### DIFF
--- a/lib/hogan_assets/tilt.rb
+++ b/lib/hogan_assets/tilt.rb
@@ -15,10 +15,10 @@ module HoganAssets
 
       text = if template_path.is_hamstache?
         raise "Unable to compile #{template_path.full_path} because haml is not available. Did you add the haml gem?" unless HoganAssets::Config.haml_available?
-        Haml::Engine.new(data, HoganAssets::Config.haml_options.merge(@options)).render
+        Haml::Engine.new(data, HoganAssets::Config.haml_options.merge(@options)).render(scope, locals)
       elsif template_path.is_slimstache?
         raise "Unable to compile #{template_path.full_path} because slim is not available. Did you add the slim gem?" unless HoganAssets::Config.slim_available?
-        Slim::Template.new(HoganAssets::Config.slim_options.merge(@options)) { data }.render
+        Slim::Template.new(HoganAssets::Config.slim_options.merge(@options)) { data }.render(scope, locals)
       else
         data
       end


### PR DESCRIPTION
Pretty self explanatory I think; during asset compile it is allowed to use the Rails Helpers if setup correctly.
